### PR TITLE
Authorization implemented for admin dashboard JWT.

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -9,9 +9,9 @@ const Navbar = () => {
   //Removes tokens from the localstorage and mongoDB
   const deleteTokens = async () => {
     try {
+      await app.post("/adminVerify/logout");
       localStorage.removeItem("token");
       localStorage.removeItem("refreshToken");
-      await app.post("/adminVerify/logout");
       window.location.reload();
     } catch (err) {
       console.log(err);

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -2,8 +2,22 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 import logo from "../assets/nomad.svg";
+import { app } from "../utils/axiosConfig";
 
 const Navbar = () => {
+
+  //Removes tokens from the localstorage and mongoDB
+  const deleteTokens = async () => {
+    try {
+      localStorage.removeItem("token");
+      localStorage.removeItem("refreshToken");
+      await app.post("/adminVerify/logout");
+      window.location.reload();
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
   return (
     <div className="navbar-container">
       <Link to="/">
@@ -14,6 +28,7 @@ const Navbar = () => {
         <Link to="/containers">Containers</Link>
         <Link to="/listings">Listings</Link>
         <Link to="/reservations">Reservations</Link>
+        <a onClick={deleteTokens}>Logout</a>
       </div>
     </div>
   );

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,18 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import { app, getLocalStorageTokens } from "./utils/axiosConfig"
+
+//Request interceptor that adds the access and refresh token for all requests that are !get
+app.interceptors.request.use((req) => {
+  if (req.method !== "get" && req.url !== "/adminVerify") {
+    req.headers.Authorization = `Bearer ${getLocalStorageTokens("token")}`
+    req.headers.RefreshToken = getLocalStorageTokens("refreshToken");
+  }
+  return req;
+}, (err) => {
+  return Promise.reject(err);
+})
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/pages/AdminPassword.js
+++ b/src/pages/AdminPassword.js
@@ -4,7 +4,7 @@ import { app } from "../utils/axiosConfig";
 
 import logo from "../assets/nomad.svg";
 
-const AdminPassword = ({ setToken }) => {
+const AdminPassword = ({ setToken, setRefreshToken, setLoggedIn }) => {
   const [password, setPassword] = useState();
   const [error, setError] = useState(false);
 
@@ -18,8 +18,12 @@ const AdminPassword = ({ setToken }) => {
       if (loginReq && loginReq.status === 200) {
         // change this to a request for generate token
         const token = loginReq.data.token;
+        const refreshToken = loginReq.data.refreshToken;
+        const loggedIn = loginReq.data.success;
+        
         setToken(token);
-        axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+        setRefreshToken(refreshToken);
+        setLoggedIn(loggedIn);
         return;
       }
     } catch {

--- a/src/utils/authAdmin.js
+++ b/src/utils/authAdmin.js
@@ -1,0 +1,27 @@
+import { app, getLocalStorageTokens } from "./axiosConfig"
+export const validToken = async () => {
+
+    //If there aren't any saved tokens in localstorage, don't verify tokens.
+    if (getLocalStorageTokens("token") === null) return;
+
+    try {
+        const authReq = await app.post("adminVerify/verifyToken");
+
+        const tokenStatus = authReq.data.status;
+        const expiredToken = authReq.data.expiredToken;
+        const newToken = authReq.data.newToken;
+
+        //Checks if the access token is valid or expired in order to update the localstorage.
+        if (!expiredToken && tokenStatus === "Success" ) {
+            return true;
+        }
+        if (expiredToken && tokenStatus === "Success") {
+            localStorage.setItem("token", JSON.stringify(newToken));
+            return true;
+        }
+        return false;
+    } catch (err) {
+        console.log(err);
+        return false;
+    }
+}

--- a/src/utils/axiosConfig.js
+++ b/src/utils/axiosConfig.js
@@ -8,3 +8,18 @@ export const app = axios.create({
       ? "https://api.vhomesgroup.com" // production
       : "http://localhost:8080", // development
 });
+
+export const getLocalStorageTokens = (tokenType) => {
+  switch (tokenType) {
+    case "token":
+      const tokenString = localStorage.getItem("token");
+      const userToken = JSON.parse(tokenString);
+      return userToken;
+    case "refreshToken":
+      const refreshTokenString = localStorage.getItem("refreshToken");
+      const refreshToken = JSON.parse(refreshTokenString);
+      return refreshToken;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
# Relevant issue
Closes [#193](https://github.com/staynomad/Nomad-Back/issues/193)

# Summary of change
- Added HTTP interceptor to send access and refresh tokens in the headers of every request.
- Implemented token verification after the user has logged into the dashboard.
- Added a logout button on the dashboard to allow users to log out of their session.
- Added refresh tokens to refresh the access tokens for the user each time they refresh the page

# Testing/Verification
<!--- How did you test your change? Reference any files you changed/added here. --->
- Try bypassing the password page by changing the URL
- Try bypassing the password page by using a fake token & refresh token value in your local storage.
- After logging in, try refreshing the page and see if you get a prompt to log in again (you shouldn't have to re-login if you have valid tokens.
- Try the logout button on the dashboard and see if your tokens are removed and check MongoDB if the refresh token is removed; therefore, you can't access the protected routes without logging in again.